### PR TITLE
Complete deployment with Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+.deploy/
+
+
+
+
 # Created by https://www.gitignore.io/api/macos,linux,windows,terraform
 
 ### Linux ###

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+# Build artifacts
 .deploy/
 
-
+# Default Logging
+logs/*
 
 
 # Created by https://www.gitignore.io/api/macos,linux,windows,terraform

--- a/README.md
+++ b/README.md
@@ -1,22 +1,49 @@
 # Usage
 
-Zip demo app:
+## Prerequisites
+
+You will need Claudia.js to package Spoke:
 
 ```sh
-$ ( cd example && zip ../example.zip lambda.js )
+$ npm install -g claudia
 ```
 
-Set variables:
+You will also need Terraform to provision AWS resources. See their [download page](https://www.terraform.io/downloads.html).
+
+## Deploying Spoke
+
+**Configuration**
+
+Copy and edit the example configuration variable declaration file:
 
 ```sh
 $ cp ./terraform.tfvars.example ./terraform.tfvars
 $ vi ./terraform.tfvars
 ```
 
-Initialize and apply Terraform:
+For most installations, this will be enough. For the complete list of configuration options, however, see [`variables.tf`](blob/master/variables.tf).
+
+**Initialize Terraform**
 
 ```sh
 $ terraform init
-$ terraform apply
 ```
 
+**Run the build script**
+
+This will compile and package the Spoke server- and client-side applications and provide you with the appropriate `terraform apply` command to run.
+
+```sh
+$ ./bin/build --path ../Spoke \
+      --domain spoke.domain.com
+      --bucket spoke.domain.com
+      --region us-east-1
+```
+
+> **Note:** You must supply the same values for the domain, bucket name, and AWS region that you provided in the Terraform configuration file above.
+
+For complete usage of the build script, see:
+
+```sh
+$ ./bin/build --help
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Usage
 
+Zip demo app:
+
+```sh
+$ ( cd example && zip ../example.zip lambda.js )
+```
+
 Set variables:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ This will compile and package the Spoke server- and client-side applications and
 
 ```sh
 $ ./bin/build --path ../Spoke \
-      --domain spoke.domain.com
-      --bucket spoke.domain.com
+      --domain spoke.domain.com \
+      --bucket spoke.domain.com \
       --region us-east-1
 ```
 

--- a/bin/build
+++ b/bin/build
@@ -1,29 +1,95 @@
 #!/bin/bash
-
-# build_and_deploy - A script to build Spoke and deploy it using Terraform.
+# 
+# Build Spoke and deploy it using Terraform.
 
 ##### Constants
 
-SPOKE_PATH=$1
 TERRAFORM_PATH=$PWD
-DEPLOY_PATH=$TERRAFORM_PATH/.deploy
+DEPLOY_PATH="$TERRAFORM_PATH/.deploy"
 
 DATE=$(date +"%Y%m%d%H%M")
 TMP_ZIP_PATH=/tmp/spoke-server-$DATE.zip
 
+SPOKE_PATH=
+SPOKE_DOMAIN=
+S3_BUCKET=
 AWS_REGION="us-east-1"
-S3_BUCKET="spoke.bchrobot.io"
-SPOKE_DOMAIN="spoke.bchrobot.io"
-
-export NODE_ENV=production
-export OUTPUT_DIR="./build"
-export PUBLIC_DIR="./build/client"
-export ASSETS_DIR="./build/client/assets"
-export STATIC_BASE_URL="https://s3.${AWS_REGION}.amazonaws.com/${S3_BUCKET}/static/"
-export BASE_URL="https://${SPOKE_DOMAIN}"
-export ASSETS_MAP_FILE="assets.json"
+AUTO_DEPLOY=0
+AUTO_YES=0
+LOG_LOCATION="$TERRAFORM_PATH/logs"
 
 ##### Functions
+
+build_spoke()
+{
+    # Clear out deploy folder
+    rm -r $DEPLOY_PATH
+    mkdir -p $DEPLOY_PATH/client
+
+    # Package the application (builds server and client before zipping)
+    echo -n "Packing application..."
+    OUTPUT=$(
+        cd "$SPOKE_PATH"
+        export NODE_ENV=production
+        export OUTPUT_DIR="./build"
+        export PUBLIC_DIR="./build/client"
+        export ASSETS_DIR="./build/client/assets"
+        export STATIC_BASE_URL="https://s3.${AWS_REGION}.amazonaws.com/${S3_BUCKET}/static/"
+        export BASE_URL="https://${SPOKE_DOMAIN}"
+        export ASSETS_MAP_FILE="assets.json"
+        claudia pack --output $TMP_ZIP_PATH 2>&1
+    )
+    if [ $? -eq 0 ]; then echo " done"; else
+        echo " error"
+        mkdir -p "$LOG_LOCATION"
+        CLAUDIA_LOG_LOCATION="$LOG_LOCATION/claudia-log.txt"
+        echo "$OUTPUT" > "$CLAUDIA_LOG_LOCATION"
+        echo "For details see: $CLAUDIA_LOG_LOCATION"
+        exit 1
+    fi
+}   # end of build_spoke
+
+gather_bundle()
+{
+    # Locate client bundle in .zip
+    BUNDLE_PATH=$(unzip -l $TMP_ZIP_PATH | grep "build/client/assets/bundle" | awk '{print $4}')
+    BUNDLE_FILENAME=$(basename -- "$BUNDLE_PATH")
+    BUNDLE_HASH=`echo "$BUNDLE_FILENAME" | cut -d '.' -f 2`
+
+    # Rename server.zip with hash for uniqueness
+    SERVER_ZIP_PATH=$DEPLOY_PATH/server.$BUNDLE_HASH.zip
+    cp $TMP_ZIP_PATH $SERVER_ZIP_PATH
+
+    # Extract client bundle
+    echo -n "Extracting client bundle for separate upload..."
+    unzip -j $SERVER_ZIP_PATH $BUNDLE_PATH -d $DEPLOY_PATH/client/ > /dev/null
+    echo " done"
+}   # end of gather_bundle
+
+terraform_command()
+{
+    local builder="terraform apply -var 'bundle_hash=$BUNDLE_HASH'"
+    if [ $AUTO_YES = "1" ]; then
+       builder="$builder -auto-approve"
+    fi
+    echo "$builder"
+}   # end of terraform_command
+
+success_message()
+{
+    echo "
+Bundling complete.
+
+Your bundle files are:
+
+    $SERVER_ZIP_PATH
+    $DEPLOY_PATH/client/$BUNDLE_FILENAME
+
+You may apply the changes with:
+
+    $(terraform_command)
+"
+}   # end of success_message
 
 usage()
 {
@@ -42,67 +108,63 @@ Usage: $0 [options]
                                        This is needed during webpack compilation.
                                        Defaults to the domain name.
     -r | --region [region]  (optional) The AWS region to deploy in. Defaults to 'us-east-1'.
+    -l | --logs [path]      (optional) Path where logs should be stored. Defaults to $PWD/logs.
     -a | --auto-deploy      (optional) If set, script will call 'terraform apply' with appropriate
                                        options rather than just printing the command.
     -y | --yes              (optional) If set, script will assume "yes" to any input prompts.
     -h | --help             Display this help text.
 EOF
-    exit 0
 }   # end of usage
 
 ##### Main
 
-# Clear out deploy folder
-rm -r $DEPLOY_PATH
-mkdir -p $DEPLOY_PATH/client
+# Process positional paramters
+# Source: http://linuxcommand.org/lc3_wss0120.php
+while [ "$1" != "" ]; do
+    case $1 in
+        -h | --help )           usage
+                                exit 0
+                                ;;
+        -p | --path )           shift
+                                SPOKE_PATH=$1
+                                ;;
+        -d | --domain )         shift
+                                SPOKE_DOMAIN=$1
+                                ;;
+        -b | --bucket )         shift
+                                S3_BUCKET=$1
+                                ;;
+        -r | --region )         shift
+                                AWS_REGION=$1
+                                ;;
+        -l | --logs )           shift
+                                LOG_LOCATION=$1
+                                ;;
+        -a | --auto-deploy )    AUTO_DEPLOY=1
+                                ;;
+        -y | --yes )            AUTO_YES=1
+                                ;;
+        * )                     echo "Unrecognized option $1. See usage:"
+                                echo ""
+                                usage
+                                exit 1
+    esac
+    shift
+done
 
-# Package the application (builds server and client before zipping)
-echo -n "Packing application..."
-(
-cd $SPOKE_PATH
-NODE_ENV=production \
-    OUTPUT_DIR="./build" \
-    PUBLIC_DIR="./build/client" \
-    ASSETS_DIR="./build/client/assets" \
-    STATIC_BASE_URL="https://s3.${AWS_REGION}.amazonaws.com/${S3_BUCKET}/static/" \
-    BASE_URL="https://${SPOKE_DOMAIN}" \
-    ASSETS_MAP_FILE="assets.json" \
-    claudia pack --output $TMP_ZIP_PATH > /dev/null
-)
-echo " done"
+# Ensure required variables are present
+if [ -z ${SPOKE_PATH} ]; then echo "You must provide the Spoke path!" && exit 1 ; fi
+if [ -z ${SPOKE_DOMAIN} ]; then echo "You must provide the Spoke domain!" && exit 1 ; fi
 
-# Locate client bundle in .zip
-BUNDLE_PATH=$(unzip -l $TMP_ZIP_PATH | grep "build/client/assets/bundle" | awk '{print $4}')
-BUNDLE_FILENAME=$(basename -- "$BUNDLE_PATH")
-BUNDLE_HASH=`echo "$BUNDLE_FILENAME" | cut -d '.' -f 2`
+# Fall back on default values
+if [ -z ${S3_BUCKET} ]; then S3_BUCKET="$SPOKE_DOMAIN"; fi
 
-# Rename server.zip with hash for uniqueness
-SERVER_ZIP_PATH=$DEPLOY_PATH/server.$BUNDLE_HASH.zip
-cp $TMP_ZIP_PATH $SERVER_ZIP_PATH
+# Build Spoke
+build_spoke
+gather_bundle
 
-# Extract client bundle
-echo -n "Extracting client bundle for separate upload..."
-unzip -j $SERVER_ZIP_PATH $BUNDLE_PATH -d $DEPLOY_PATH/client/ > /dev/null
-echo " done"
-
-SUCCESS_MESSAGE="
-Bundling complete.
-
-Your bundle files are:
-
-    $SERVER_ZIP_PATH
-    $DEPLOY_PATH/client/$BUNDLE_FILENAME
-
-You may apply the changes with:
-
-    terraform apply -var 'bundle_hash=$BUNDLE_HASH'
-"
-
-# TODO: Add real flag for running it automatically
-RUN_AUTOMATICALLY=false
-
-if [ $RUN_AUTOMATICALLY = true ]; then
-   echo "Run 'terraform apply' automatically"
+if [ $AUTO_DEPLOY = "1" ]; then
+   eval $(terraform_command)
 else
-    echo "$SUCCESS_MESSAGE"
+    success_message
 fi

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# build_and_deploy - A script to build Spoke and deploy it using Terraform.
+
+##### Constants
+
+SPOKE_PATH=$1
+TERRAFORM_PATH=$PWD
+DEPLOY_PATH=$TERRAFORM_PATH/.deploy
+
+DATE=$(date +"%Y%m%d%H%M")
+TMP_ZIP_PATH=/tmp/spoke-server-$DATE.zip
+
+AWS_REGION="us-east-1"
+S3_BUCKET="spoke.bchrobot.io"
+
+export NODE_ENV=production
+export OUTPUT_DIR="./build"
+export PUBLIC_DIR="./build/client"
+export ASSETS_DIR="./build/client/assets"
+export STATIC_BASE_URL="https://s3.${AWS_REGION}.amazonaws.com/${S3_BUCKET}/static/"
+export BASE_URL="https://${S3_BUCKET}"
+export ASSETS_MAP_FILE="assets.json"
+
+
+##### Main
+
+# Clear out deploy folder
+rm -r $DEPLOY_PATH
+mkdir -p $DEPLOY_PATH/client
+
+# Package the application (builds server and client before zipping)
+echo -n "Packing application..."
+(
+cd $SPOKE_PATH
+NODE_ENV=production \
+    OUTPUT_DIR="./build" \
+    PUBLIC_DIR="./build/client" \
+    ASSETS_DIR="./build/client/assets" \
+    STATIC_BASE_URL="https://s3.${AWS_REGION}.amazonaws.com/${S3_BUCKET}/static/" \
+    BASE_URL="https://${S3_BUCKET}" \
+    ASSETS_MAP_FILE="assets.json" \
+    claudia pack --output $TMP_ZIP_PATH > /dev/null
+)
+echo " done"
+
+# Locate client bundle in .zip
+BUNDLE_PATH=$(unzip -l $TMP_ZIP_PATH | grep "build/client/assets/bundle" | awk '{print $4}')
+BUNDLE_FILENAME=$(basename -- "$BUNDLE_PATH")
+BUNDLE_HASH=`echo "$BUNDLE_FILENAME" | cut -d '.' -f 2`
+
+# Rename server.zip with hash for uniqueness
+SERVER_ZIP_PATH=$DEPLOY_PATH/server.$BUNDLE_HASH.zip
+cp $TMP_ZIP_PATH $SERVER_ZIP_PATH
+
+# Extract client bundle
+echo -n "Extracting client bundle for separate upload..."
+unzip -j $SERVER_ZIP_PATH $BUNDLE_PATH -d $DEPLOY_PATH/client/ > /dev/null
+echo " done"
+
+# Print completion message
+cat << EOF
+
+Bundling complete.
+
+Your bundle files are:
+
+    $SERVER_ZIP_PATH
+    $DEPLOY_PATH/client/$BUNDLE_FILENAME
+
+You may apply the changes with:
+
+    terraform apply -var 'bundle_hash=$BUNDLE_HASH'
+
+EOF
+
+
+
+# TODO: Add flag for running it automatically:
+
+# if [Run automatically]; then
+# ( cd $TERRAFORM_PATH && TF_VAR_bundle_hash="$BUNDLE_HASH" terraform apply )
+# fi

--- a/bin/build
+++ b/bin/build
@@ -23,6 +23,33 @@ export STATIC_BASE_URL="https://s3.${AWS_REGION}.amazonaws.com/${S3_BUCKET}/stat
 export BASE_URL="https://${SPOKE_DOMAIN}"
 export ASSETS_MAP_FILE="assets.json"
 
+##### Functions
+
+usage()
+{
+    cat <<EOF
+Build the Spoke project and deploy to AWS.
+
+Requires:
+    Claudia     npm install -g claudia
+    Terraform   https://www.terraform.io/downloads.html
+
+Usage: $0 [options]
+
+    -p | --path [path]      (required) The path to the Spoke project folder.
+    -d | --domain [domain]  (required) The instance domain name. Ex: spoke.example.com
+    -b | --bucket [name]    (optional) The name of the AWS S3 bucket that Terraform will create.
+                                       This is needed during webpack compilation.
+                                       Defaults to the domain name.
+    -r | --region [region]  (optional) The AWS region to deploy in. Defaults to 'us-east-1'.
+    -a | --auto-deploy      (optional) If set, script will call 'terraform apply' with appropriate
+                                       options rather than just printing the command.
+    -y | --yes              (optional) If set, script will assume "yes" to any input prompts.
+    -h | --help             Display this help text.
+EOF
+    exit 0
+}   # end of usage
+
 ##### Main
 
 # Clear out deploy folder

--- a/bin/build
+++ b/bin/build
@@ -13,15 +13,15 @@ TMP_ZIP_PATH=/tmp/spoke-server-$DATE.zip
 
 AWS_REGION="us-east-1"
 S3_BUCKET="spoke.bchrobot.io"
+SPOKE_DOMAIN="spoke.bchrobot.io"
 
 export NODE_ENV=production
 export OUTPUT_DIR="./build"
 export PUBLIC_DIR="./build/client"
 export ASSETS_DIR="./build/client/assets"
 export STATIC_BASE_URL="https://s3.${AWS_REGION}.amazonaws.com/${S3_BUCKET}/static/"
-export BASE_URL="https://${S3_BUCKET}"
+export BASE_URL="https://${SPOKE_DOMAIN}"
 export ASSETS_MAP_FILE="assets.json"
-
 
 ##### Main
 
@@ -38,7 +38,7 @@ NODE_ENV=production \
     PUBLIC_DIR="./build/client" \
     ASSETS_DIR="./build/client/assets" \
     STATIC_BASE_URL="https://s3.${AWS_REGION}.amazonaws.com/${S3_BUCKET}/static/" \
-    BASE_URL="https://${S3_BUCKET}" \
+    BASE_URL="https://${SPOKE_DOMAIN}" \
     ASSETS_MAP_FILE="assets.json" \
     claudia pack --output $TMP_ZIP_PATH > /dev/null
 )

--- a/bin/build
+++ b/bin/build
@@ -58,9 +58,7 @@ echo -n "Extracting client bundle for separate upload..."
 unzip -j $SERVER_ZIP_PATH $BUNDLE_PATH -d $DEPLOY_PATH/client/ > /dev/null
 echo " done"
 
-# Print completion message
-cat << EOF
-
+SUCCESS_MESSAGE="
 Bundling complete.
 
 Your bundle files are:
@@ -71,13 +69,13 @@ Your bundle files are:
 You may apply the changes with:
 
     terraform apply -var 'bundle_hash=$BUNDLE_HASH'
+"
 
-EOF
+# TODO: Add real flag for running it automatically
+RUN_AUTOMATICALLY=false
 
-
-
-# TODO: Add flag for running it automatically:
-
-# if [Run automatically]; then
-# ( cd $TERRAFORM_PATH && TF_VAR_bundle_hash="$BUNDLE_HASH" terraform apply )
-# fi
+if [ $RUN_AUTOMATICALLY = true ]; then
+   echo "Run 'terraform apply' automatically"
+else
+    echo "$SUCCESS_MESSAGE"
+fi

--- a/example/lambda.js
+++ b/example/lambda.js
@@ -1,0 +1,12 @@
+'use strict';
+
+exports.handler = function (event, context, callback) {
+    var response = {
+        statusCode: 200,
+        headers: {
+            'Content-Type': 'text/html; charset=utf-8',
+        },
+        body: "<p>Hello world!</p>",
+    };
+    callback(null, response);
+};

--- a/main.tf
+++ b/main.tf
@@ -291,7 +291,7 @@ resource "aws_db_subnet_group" "postgres" {
 
 # Create RDS Postgres instance
 # Source: https://www.terraform.io/docs/providers/aws/r/db_instance.html
-resource "aws_db_instance" "default" {
+resource "aws_db_instance" "spoke" {
   allocated_storage      = "${var.rds_size}"
   storage_type           = "gp2"
   engine                 = "postgres"
@@ -304,6 +304,7 @@ resource "aws_db_instance" "default" {
   option_group_name      = "default:postgres-10"
   parameter_group_name   = "default.postgres10"
   publicly_accessible    = true
+  skip_final_snapshot    = true
   db_subnet_group_name   = "${aws_db_subnet_group.postgres.name}"
   vpc_security_group_ids = ["${aws_security_group.postgres.id}"]
 }
@@ -420,6 +421,60 @@ resource "aws_lambda_function" "spoke" {
   environment = {
     variables = {
       NODE_ENV = "production"
+      JOBS_SAME_PROCESS = "1"
+      SUPPRESS_SEED_CALLS = "${var.spoke_suppress_seed}"
+      SUPPRESS_SELF_INVITE = "${var.spoke_suppress_self_invite}"
+      AWS_ACCESS_AVAILABLE = "1"
+      AWS_S3_BUCKET_NAME = "${var.spoke_domain}"
+      APOLLO_OPTICS_KEY = ""
+      DEFAULT_SERVICE = "${var.spoke_default_service}"
+      OUTPUT_DIR = "./build"
+      PUBLIC_DIR = "./build/client"
+      ASSETS_DIR = "./build/client/assets"
+      STATIC_BASE_URL = "https://s3.${var.aws_region}.amazonaws.com/${var.spoke_domain}/static/"
+      BASE_URL = "https://${var.spoke_domain}"
+      S3_STATIC_PATH = "s3://${var.spoke_domain}/static/"
+      ASSETS_MAP_FILE = "assets.json"
+      DB_HOST = "${aws_db_instance.spoke.address}"
+      DB_PORT = "${aws_db_instance.spoke.port}"
+      DB_NAME = "${aws_db_instance.spoke.name}"
+      DB_USER = "${aws_db_instance.spoke.username}"
+      DB_PASSWORD = "${var.rds_password}"
+      DB_TYPE = "pg"
+      DB_KEY = ""
+      PGSSLMODE = "require"
+      AUTH0_DOMAIN = "${var.spoke_auth0_domain}"
+      AUTH0_CLIENT_ID = "${var.spoke_auth0_client_id}"
+      AUTH0_CLIENT_SECRET = "${var.spoke_auth0_client_secret}"
+      SESSION_SECRET = "${var.spoke_session_secret}"
+      NEXMO_API_KEY = "${var.spoke_nexmo_api_key}"
+      NEXMO_API_SECRET = "${var.spoke_nexmo_api_secret}"
+      TWILIO_API_KEY = "${var.spoke_twilio_api_key}"
+      TWILIO_MESSAGE_SERVICE_SID = "${var.spoke_twilio_message_service_sid}"
+      TWILIO_APPLICATION_SID = "${var.spoke_twilio_message_service_sid}"
+      TWILIO_AUTH_TOKEN = "${var.spoke_twilio_auth_token}"
+      TWILIO_STATUS_CALLBACK_URL = "${var.spoke_twilio_status_callback_url}"
+      EMAIL_HOST = "${var.spoke_email_host}"
+      EMAIL_HOST_PASSWORD = "${var.spoke_email_host_password}"
+      EMAIL_HOST_USER = "${var.spoke_email_host_user}"
+      EMAIL_HOST_PORT = "${var.spoke_email_host_port}"
+      EMAIL_FROM = "${var.spoke_email_from}"
+      ROLLBAR_CLIENT_TOKEN = "${var.spoke_rollbar_client_token}"
+      ROLLBAR_ACCESS_TOKEN = "${var.spoke_rollbar_client_token}"
+      ROLLBAR_ENDPOINT = "${var.spoke_rollbar_endpoint}"
+      DST_REFERENCE_TIMEZONE = "${var.spoke_timezone}"
+      TZ = "${var.spoke_timezone}"
+      ACTION_HANDLERS = "${var.spoke_action_handlers}"
+      AK_BASEURL = "${var.spoke_ak_baseurl}"
+      AK_SECRET = "${var.spoke_ak_secret}"
+      MAILGUN_API_KEY = "${var.spoke_mailgun_api_key}"
+      MAILGUN_DOMAIN = "${var.spoke_mailgun_domain}"
+      MAILGUN_PUBLIC_KEY = "${var.spoke_mailgun_public_key}"
+      MAILGUN_SMTP_LOGIN = "${var.spoke_mailgun_smtp_login}"
+      MAILGUN_SMTP_PASSWORD = "${var.spoke_mailgun_smtp_password}"
+      MAILGUN_SMTP_PORT = "${var.spoke_mailgun_smtp_port}"
+      MAILGUN_SMTP_SERVER = "${var.spoke_mailgun_smtp_server}"
+      LAMBDA_DEBUG_LOG = "${var.spoke_lambda_debug}"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -393,3 +393,33 @@ resource "aws_s3_bucket_object" "spoke_payload" {
   source = "example.zip"
   etag   = "${md5(file("example.zip"))}"
 }
+
+
+
+# Create Lambda function
+# https://www.terraform.io/docs/providers/aws/r/lambda_function.html
+resource "aws_lambda_function" "spoke" {
+  function_name = "Spoke"
+  description   = "Spoke P2P Texting Platform"
+
+  s3_bucket = "${var.spoke_domain}"
+  s3_key    = "deploy/example.zip"
+
+  handler     = "lambda.handler"
+  runtime     = "nodejs6.10"
+  memory_size = "512"
+  timeout     = "300"
+
+  role = "${aws_iam_role.spoke_lambda.arn}"
+
+  vpc_config = {
+    subnet_ids          = ["${aws_subnet.private_a.id}", "${aws_subnet.private_b.id}"]
+    security_group_ids  = ["${aws_security_group.lambda.id}"]
+  }
+
+  environment = {
+    variables = {
+      NODE_ENV = "production"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -395,6 +395,7 @@ resource "aws_s3_bucket_object" "client_payload" {
   key    = "static/bundle.${var.bundle_hash}.js"
   source = "./.deploy/client/bundle.${var.bundle_hash}.js"
   etag   = "${md5(file("./.deploy/client/bundle.${var.bundle_hash}.js"))}"
+  depends_on = ["aws_s3_bucket.spoke_bucket"]
 }
 
 # Upload Lambda Function
@@ -403,6 +404,7 @@ resource "aws_s3_bucket_object" "server_payload" {
   key    = "deploy/server.${var.bundle_hash}.zip"
   source = "./.deploy/server.${var.bundle_hash}.zip"
   etag   = "${md5(file("./.deploy/server.${var.bundle_hash}.zip"))}"
+  depends_on = ["aws_s3_bucket.spoke_bucket"]
 }
 
 
@@ -460,11 +462,11 @@ resource "aws_lambda_function" "spoke" {
       SESSION_SECRET = "${var.spoke_session_secret}"
       NEXMO_API_KEY = "${var.spoke_nexmo_api_key}"
       NEXMO_API_SECRET = "${var.spoke_nexmo_api_secret}"
-      TWILIO_API_KEY = "${var.spoke_twilio_api_key}"
+      TWILIO_API_KEY = "${var.spoke_twilio_account_sid}"
       TWILIO_MESSAGE_SERVICE_SID = "${var.spoke_twilio_message_service_sid}"
       TWILIO_APPLICATION_SID = "${var.spoke_twilio_message_service_sid}"
       TWILIO_AUTH_TOKEN = "${var.spoke_twilio_auth_token}"
-      TWILIO_STATUS_CALLBACK_URL = "${var.spoke_twilio_status_callback_url}"
+      TWILIO_STATUS_CALLBACK_URL = "https://${var.spoke_domain}/twilio-message-report"
       EMAIL_HOST = "${var.spoke_email_host}"
       EMAIL_HOST_PASSWORD = "${var.spoke_email_host_password}"
       EMAIL_HOST_USER = "${var.spoke_email_host_user}"

--- a/main.tf
+++ b/main.tf
@@ -259,6 +259,14 @@ resource "aws_security_group" "postgres" {
     to_port     = 5432
     protocol    = "tcp"
     self        = true
+    description = "Postgres access"
+  }
+
+  ingress {
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
     description = "Postgres traffic from anywhere"
   }
 
@@ -410,7 +418,7 @@ resource "aws_s3_bucket_object" "server_payload" {
 
 
 # Create Lambda function
-# https://www.terraform.io/docs/providers/aws/r/lambda_function.html
+# Source: https://www.terraform.io/docs/providers/aws/r/lambda_function.html
 resource "aws_lambda_function" "spoke" {
   function_name = "Spoke"
   description   = "Spoke P2P Texting Platform"

--- a/main.tf
+++ b/main.tf
@@ -382,3 +382,14 @@ resource "aws_iam_role_policy" "vpc_access_execution" {
 }
 EOF
 }
+
+
+
+# Upload Lambda Function
+# Source: https://www.terraform.io/docs/providers/aws/r/s3_bucket_object.html
+resource "aws_s3_bucket_object" "spoke_payload" {
+  bucket = "${var.spoke_domain}"
+  key    = "deploy/example.zip"
+  source = "example.zip"
+  etag   = "${md5(file("example.zip"))}"
+}

--- a/main.tf
+++ b/main.tf
@@ -423,3 +423,81 @@ resource "aws_lambda_function" "spoke" {
     }
   }
 }
+
+
+
+# Create API Gateway
+# Source: https://www.terraform.io/docs/providers/aws/r/api_gateway_rest_api.html
+resource "aws_api_gateway_rest_api" "spoke" {
+  name        = "SpokeAPIGateway"
+  description = "Spoke P2P Testing Platform"
+}
+
+
+# Proxy path
+resource "aws_api_gateway_resource" "proxy" {
+  rest_api_id = "${aws_api_gateway_rest_api.spoke.id}"
+  parent_id   = "${aws_api_gateway_rest_api.spoke.root_resource_id}"
+  path_part   = "{proxy+}"
+}
+
+resource "aws_api_gateway_method" "proxy" {
+  rest_api_id   = "${aws_api_gateway_rest_api.spoke.id}"
+  resource_id   = "${aws_api_gateway_resource.proxy.id}"
+  http_method   = "ANY"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "lambda" {
+  rest_api_id = "${aws_api_gateway_rest_api.spoke.id}"
+  resource_id = "${aws_api_gateway_method.proxy.resource_id}"
+  http_method = "${aws_api_gateway_method.proxy.http_method}"
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = "${aws_lambda_function.spoke.invoke_arn}"
+}
+
+
+# Root path
+resource "aws_api_gateway_method" "proxy_root" {
+  rest_api_id   = "${aws_api_gateway_rest_api.spoke.id}"
+  resource_id   = "${aws_api_gateway_rest_api.spoke.root_resource_id}"
+  http_method   = "ANY"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "lambda_root" {
+  rest_api_id = "${aws_api_gateway_rest_api.spoke.id}"
+  resource_id = "${aws_api_gateway_method.proxy_root.resource_id}"
+  http_method = "${aws_api_gateway_method.proxy_root.http_method}"
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = "${aws_lambda_function.spoke.invoke_arn}"
+}
+
+
+# Gateway Deployment - activate the above configuration
+resource "aws_api_gateway_deployment" "spoke" {
+  depends_on = [
+    "aws_api_gateway_integration.lambda",
+    "aws_api_gateway_integration.lambda_root",
+  ]
+
+  rest_api_id = "${aws_api_gateway_rest_api.spoke.id}"
+  stage_name  = "latest"
+}
+
+
+# Allow API Gateway to access Lambda
+resource "aws_lambda_permission" "api_gw" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_function.spoke.arn}"
+  principal     = "apigateway.amazonaws.com"
+
+  # The /*/* portion grants access from any method on any resource
+  # within the API Gateway "REST API".
+  source_arn = "${aws_api_gateway_deployment.spoke.execution_arn}/*/*"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,30 +5,18 @@
 # 
 # Source: https://www.terraform.io/intro/getting-started/outputs.html
 
-output "VPC ID" {
-  value = "${aws_vpc.spoke_vpc.id}"
+output "RDS Host" {
+  value = "${aws_db_instance.spoke.address}"
 }
 
-output "Public Subnets" {
-  value = "${aws_subnet.public_a.id}, ${aws_subnet.public_b.id}"
-}
-
-output "Private Subnets" {
-  value = "${aws_subnet.private_a.id}, ${aws_subnet.private_b.id}"
-}
-
-output "RDS Security Group" {
-  value = "${aws_security_group.postgres.id}"
-}
-
-output "Lambda Security Group" {
-  value = "${aws_security_group.lambda.id}"
+output "Bundle Hash" {
+  value = "${var.bundle_hash}"
 }
 
 output "S3 Bucket Name" {
   value = "${var.spoke_domain}"
 }
 
-output "Base URL" {
+output "Base API Gateway URL" {
   value = "${aws_api_gateway_deployment.spoke.invoke_url}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,3 +28,7 @@ output "Lambda Security Group" {
 output "S3 Bucket Name" {
   value = "${var.spoke_domain}"
 }
+
+output "Base URL" {
+  value = "${aws_api_gateway_deployment.spoke.invoke_url}"
+}

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,9 +1,21 @@
 aws_access_key        = "XXXXXXXXXXXXXXXXXX"
 aws_secret_key        = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+rds_password          = "EXTRA_SECRET_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 spoke_domain          = "spoke.example.com"
-rds_password          = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX5YN7"
-spoke_session_secret  = "EXTRA_SECRET"
+
+spoke_session_secret  = "EXTRA_SECRET_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+spoke_action_handlers = ""
 
 spoke_auth0_domain        = "campaign.auth0.com"
 spoke_auth0_client_id     = "XXXXXXXXXXXXXXXXXX"
 spoke_auth0_client_secret = "XXXXXXXXXXXXXXXXXX"
+
+spoke_twilio_account_sid          = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+spoke_twilio_auth_token           = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+spoke_twilio_message_service_sid  = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
+# spoke_email_host          = ""
+# spoke_email_host_port     = ""
+# spoke_email_host_user     = ""
+# spoke_email_host_password = ""
+# spoke_email_from          = ""

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,4 +1,9 @@
-aws_access_key  = "XXXXXXXXXXXXXXXXXX"
-aws_secret_key  = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-spoke_domain    = "spoke.example.com"
-rds_password    = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX5YN7"
+aws_access_key        = "XXXXXXXXXXXXXXXXXX"
+aws_secret_key        = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+spoke_domain          = "spoke.example.com"
+rds_password          = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX5YN7"
+spoke_session_secret  = "EXTRA_SECRET"
+
+spoke_auth0_domain        = "campaign.auth0.com"
+spoke_auth0_client_id     = "XXXXXXXXXXXXXXXXXX"
+spoke_auth0_client_secret = "XXXXXXXXXXXXXXXXXX"

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,10 @@
 # Source: https://www.terraform.io/intro/getting-started/variables.html
 
 
+########################
+# AWS Deploy Variables #
+########################
+
 variable "aws_access_key" {
   description = "AWS Access Key."
 }
@@ -50,6 +54,10 @@ variable "rds_username" {
 
 variable "rds_password" {
   description = "The password for the Postgres instance user."
+}
+
+variable "bundle_hash" {
+  description = "Hash of client bundle.js"
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -51,3 +51,195 @@ variable "rds_username" {
 variable "rds_password" {
   description = "The password for the Postgres instance user."
 }
+
+
+###################
+# Spoke Variables #
+###################
+
+# Spoke
+
+variable "spoke_suppress_seed" {
+  description = "Prevent seed calls from being run automatically."
+  default     = "1"
+}
+
+variable "spoke_suppress_self_invite" {
+  description = "Prevent users from being able to create organizations."
+  default     = "1"
+}
+
+variable "spoke_session_secret" {
+  description = "Session secret."
+  default     = ""
+}
+
+variable "spoke_timezone" {
+  description = "Timezone that Spoke is operating in."
+  default     = "America/New_York"
+}
+
+variable "spoke_lambda_debug" {
+  description = "Lambda debug flag."
+  default     = "0"
+}
+
+
+# SMS
+
+variable "spoke_default_service" {
+  description = "The SMS service to use."
+  default     = "twilio"
+}
+
+## Twilio
+
+variable "spoke_twilio_api_key" {
+  description = "Twilio API key."
+  default     = ""
+}
+
+variable "spoke_twilio_auth_token" {
+  description = "Twilio auth token."
+  default     = ""
+}
+
+variable "spoke_twilio_message_service_sid" {
+  description = "Twilio Message Service SID."
+  default     = ""
+}
+
+variable "spoke_twilio_status_callback_url" {
+  description = "Twilio status callback URL."
+  default     = ""
+}
+
+## Nexmo
+
+variable "spoke_nexmo_api_key" {
+  description = "Nexmo API key."
+  default     = ""
+}
+
+variable "spoke_nexmo_api_secret" {
+  description = "Nexmo API secret."
+  default     = ""
+}
+
+
+# Auth0
+
+variable "spoke_auth0_domain" {
+  description = "Auth0 domain."
+  default     = "domain.auth0.com"
+}
+
+variable "spoke_auth0_client_id" {
+  description = "Auth0 client ID."
+  default     = ""
+}
+
+variable "spoke_auth0_client_secret" {
+  description = "Auth0 client secret."
+  default     = ""
+}
+
+
+# Email
+
+## SMTP
+
+variable "spoke_email_host" {
+  description = "Email host."
+  default     = ""
+}
+
+variable "spoke_email_host_port" {
+  description = "Email host port."
+  default     = ""
+}
+
+variable "spoke_email_host_user" {
+  description = "Email host username."
+  default     = ""
+}
+
+variable "spoke_email_host_password" {
+  description = "Email host password."
+  default     = ""
+}
+
+variable "spoke_email_from" {
+  description = "Address to send emails from."
+  default     = ""
+}
+
+## Mailgun
+
+variable "spoke_mailgun_api_key" {
+  description = "Mailgun API key."
+  default     = ""
+}
+
+variable "spoke_mailgun_domain" {
+  description = "Mailgun domain."
+  default     = ""
+}
+
+variable "spoke_mailgun_public_key" {
+  description = "Mailgun public key."
+  default     = ""
+}
+
+variable "spoke_mailgun_smtp_login" {
+  description = "Mailgun SMTP login username."
+  default     = ""
+}
+
+variable "spoke_mailgun_smtp_password" {
+  description = "Mailgun SMTP login password."
+  default     = ""
+}
+
+variable "spoke_mailgun_smtp_port" {
+  description = "Mailgun SMTP port."
+  default     = "587"
+}
+
+variable "spoke_mailgun_smtp_server" {
+  description = "Mailgun SMTP host."
+  default     = "smtp.mailgun.org"
+}
+
+
+# Action Handlers
+
+variable "spoke_action_handlers" {
+  description = "Enabled Action Handlers."
+  default     = ""
+}
+
+## ActionKit
+
+variable "spoke_ak_baseurl" {
+  description = "ActionKit base URL."
+  default     = ""
+}
+
+variable "spoke_ak_secret" {
+  description = "ActionKit secret."
+  default     = ""
+}
+
+
+# Rollbar
+
+variable "spoke_rollbar_client_token" {
+  description = "Rollbar client token."
+  default     = ""
+}
+
+variable "spoke_rollbar_endpoint" {
+  description = "Rollbar endpoint."
+  default     = "https://api.rollbar.com/api/1/item/"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -102,8 +102,8 @@ variable "spoke_default_service" {
 
 ## Twilio
 
-variable "spoke_twilio_api_key" {
-  description = "Twilio API key."
+variable "spoke_twilio_account_sid" {
+  description = "Twilio Account SID."
   default     = ""
 }
 
@@ -114,11 +114,6 @@ variable "spoke_twilio_auth_token" {
 
 variable "spoke_twilio_message_service_sid" {
   description = "Twilio Message Service SID."
-  default     = ""
-}
-
-variable "spoke_twilio_status_callback_url" {
-  description = "Twilio status callback URL."
   default     = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -18,13 +18,11 @@ variable "aws_secret_key" {
 }
 
 variable "aws_region" {
-  description = "AWS region to launch servers."
-  default     = "us-east-1"
+  description = "AWS region to launch servers. Ex. us-east-1"
 }
 
-variable "spoke_domain" {
-  description = "The domain that Spoke will be running on. Also used to create a globally unique S3 bucket."
-  default     = "spoke.example.com"
+variable "s3_bucket_name" {
+  description = "Create a globally unique S3 bucket. Usually the same as the domain: spoke.example.com"
 }
 
 variable "rds_size" {
@@ -66,6 +64,10 @@ variable "bundle_hash" {
 ###################
 
 # Spoke
+
+variable "spoke_domain" {
+  description = "The domain that Spoke will be running on. Ex. spoke.example.com"
+}
 
 variable "spoke_suppress_seed" {
   description = "Prevent seed calls from being run automatically."


### PR DESCRIPTION
This extends the Terraform module to take on the remaining AWS provisioning that Claudia.js had been doing. It adds a bash script to handle packing and "versioning" of the documents as well.

ToDo:

- [x] Update documentation in readme with how to configure and use with the new bash script
- [x] Take the following [positional parameters] in bash script:
    * `-p | --path [Spoke path]` (required) - The path to the Spoke project folder
    * `-b | --bucket [AWS S3 bucket name]` (required) - The name of the S3 bucket that terraform will create. This is needed during the compilation. There is probably a better way of handling this that doesn't require specifying the variable twice.
    * `-r | --region [AWS region]` (optional; default `us-east-1`) - The AWS region to deploy in
    * `-a | --auto-deploy` (optional; default false) - If true, script will call `terraform apply` with appropriate options rather than just printing the command.
    * `-y | --yes` (optional; default false) - If true, script will assume "yes" to any input prompts
- [x] Add the above usage instructions to bash script itself

[positional parameters]: http://linuxcommand.org/lc3_wss0120.php